### PR TITLE
Add drag select for calendar

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,6 +1,9 @@
 const days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 const times = Array.from({length:14}, (_,i)=>i+8); // 8am-21pm
 
+let isDragging = false;
+let dragSelect = false;
+
 function formatTime(hour){
     const ampm = hour < 12 ? 'am' : 'pm';
     const h = hour % 12 === 0 ? 12 : hour % 12;
@@ -28,13 +31,27 @@ function createCalendar(){
             const cell=document.createElement('td');
             cell.dataset.day=d;
             cell.dataset.time=t;
-            cell.addEventListener('click',()=>cell.classList.toggle('selected'));
+
+            cell.addEventListener('mousedown',e=>{
+                e.preventDefault();
+                isDragging = true;
+                dragSelect = !cell.classList.contains('selected');
+                cell.classList.toggle('selected', dragSelect);
+            });
+
+            cell.addEventListener('mouseover',()=>{
+                if(isDragging){
+                    cell.classList.toggle('selected', dragSelect);
+                }
+            });
+
             row.appendChild(cell);
         });
         table.appendChild(row);
     });
 
     cal.appendChild(table);
+    document.addEventListener('mouseup',()=>{isDragging=false;});
 }
 
 function getAvailability(){

--- a/static/style.css
+++ b/static/style.css
@@ -47,6 +47,7 @@ input[type="text"], input[type="email"] {
 #calendar td {
     cursor: pointer;
     height: 30px;
+    user-select: none;
 }
 #calendar td.selected {
     background: #007bff;


### PR DESCRIPTION
## Summary
- enable selecting hours by click-and-dragging across calendar cells
- prevent text selection while dragging

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_68424af714e4832db485f38c86b3711b